### PR TITLE
Update data ht2190a

### DIFF
--- a/src/export_from_inboveg/HT31xx_LSVI.Rmd
+++ b/src/export_from_inboveg/HT31xx_LSVI.Rmd
@@ -102,7 +102,7 @@ Type <- c("Decimaal getal", "Ja/nee", rep("Percentage", 4), "Ja/nee",
 invoervereisten_join <- data.frame(rel_var, Criterium, Indicator, Voorwaarde, 
                                    Type) %>% 
   mutate(Invoertype = NA)
-# suggestie Toon: var in HT31xx_data_prep direct veranderen in Voorwaarde (to do later)
+# suggestie Toon: var in HT31xx_data_prep direct veranderen in Voorwaarde (to do later - veel werk)
 ```
 
 ```{r}
@@ -209,15 +209,23 @@ Warning messages:
 2: In berekenLSVIbasis(Versie = "Versie 3", Kwaliteitsniveau = "1",  :
   Volgende records uit Data_voorwaarden kunnen niet gekoppeld worden aan indicatoren uit de databank omdat de criterium-indicator-voorwaarde-combinatie niet voorkomt bij de LSVI-regels van het opgegeven habitattype: 
   <IV2021110112004579, Structuur, verticale structuur, bedekking helofyten> 
-  --> habitattype 3130n; opmerking te negeren; dit werd extra genoteerd  
+    --> habitattype 3130n; opmerking te negeren; dit werd extra genoteerd  
   <IV2021103012423456, Structuur, horizontale structuur, grootste vegetatievlek in m²>
-  --> habitattype 3160; opmerking te negeren; dit werd extra genoteerd 
-
+    --> habitattype 3160; opmerking te negeren; dit werd extra genoteerd 
+  <IV2024011111212549, Verstoring, verzuring, bedekking verzuring> 
+    --> habitattype 3150; opmerking te negeren; bedekking verzuring is eigenlijk niet relevant; werd blijkbaar extra genoteerd
+  <IV2024011616290864, Structuur, verticale structuur, bedekking helofyten> 
+    --> habitattype 3130n; % helofyten teveel; opgaande vegetatie ontbreekt
+  <IV2024011710122457, Structuur, verticale structuur, bedekking helofyten> 
+    --> habitattype 3130n; % helofyten teveel; opgaande vegetatie ontbreekt
+  <IV2023112914403467, Structuur, horizontale structuur, grootste vegetatievlek in m²>
+    --> habitattype 3160; opmerking te negeren; dit werd extra genoteerd (tenzij dit hoort bij verzuring; dit ontbreekt)
+ 
 3: In berekenLSVIbasis(Versie = "Versie 3", Kwaliteitsniveau = "1",  :
   De waarde(n) voor de voorwaarde(n) contact met 7110 of 7140_oli, % begroeid met opgaande vegetatie (VoorwaardeID 2139, 2) kunnen niet berekend worden voor opname(n) IV2021012910413902, IV2021103012423456, IV2023011817014307,... Geef de waarde voor deze voorwaarde rechtstreeks in als input van de functie 'berekenLSVIBasis' via tabel 'Data_voorwaarden' (zie ?berekenLSVIbasis voor meer info). Vermeld hierbij Criterium = Structuur, Indicator = horizontale structuur, verticale structuur en Voorwaarde = contact met 7110 of 7140_oli, % begroeid met opgaande vegetatie.
   --> missing values; aan te vullen door Jo/Kevin (to do opvolgen; ook voor 2190)
 
-4: There were 2 warnings in `summarise()`.
+4: There were 12 warnings in `summarise()`.
 The first warning was:
 ℹ In argument: `Index_min_criterium = min(.data$Verschilscore, na.rm = na.rm)`.
 ℹ In group 1321: `ID = "IV2021012910413902"`, `Habitattype = "3160"`, `Versie = "Versie 3"`, `Criterium = "Structuur"`, `Kwaliteitsniveau =

--- a/src/export_from_inboveg/HT31xx_LSVI.Rmd
+++ b/src/export_from_inboveg/HT31xx_LSVI.Rmd
@@ -49,7 +49,8 @@ invoervereisten <- geefInvoervereisten(Versie = "Versie 3",
 invoervereisten %>% 
   kable() %>% 
   kable_styling() %>% 
-  scroll_box(width = "800px")
+  scroll_box(width = "800px") %>% 
+  scroll_box(height = "500px")
 
 soortenlijsten <- geefSoortenlijst(Versie = "Versie 3",
                                    Habitattype = c("3110", "3130", "3140", "3150", "3160", "2190"),
@@ -166,7 +167,7 @@ data_soortenkenmerken <- vegetation %>%
     name == "Chara hispida L." ~ "Chara major",
     # Chara hispida L. wordt niet herkend door berekenLSVIbasis; 
     # door omzetting naar de oude naam Chara major wordt dit wel correct doorgerekend; 
-    # to do (later) aanpassing in inboveg-survey: 
+    # to do (later; indien nodig) aanpassing in inboveg-survey: 
     # 1/ toevoeging Chara hispida aan Futon-lijst of 
     # juiste Futon-lijst toevoegen aan survey (Sophie V./Pieter VdB); 
     # 2/ daarna aanpassen in LSVI-rekenmodule (Els L.)
@@ -222,7 +223,7 @@ Warning messages:
     --> habitattype 3160; opmerking te negeren; dit werd extra genoteerd (tenzij dit hoort bij verzuring; dit ontbreekt)
  
 3: In berekenLSVIbasis(Versie = "Versie 3", Kwaliteitsniveau = "1",  :
-  De waarde(n) voor de voorwaarde(n) contact met 7110 of 7140_oli, % begroeid met opgaande vegetatie (VoorwaardeID 2139, 2) kunnen niet berekend worden voor opname(n) IV2021012910413902, IV2021103012423456, IV2023011817014307,... Geef de waarde voor deze voorwaarde rechtstreeks in als input van de functie 'berekenLSVIBasis' via tabel 'Data_voorwaarden' (zie ?berekenLSVIbasis voor meer info). Vermeld hierbij Criterium = Structuur, Indicator = horizontale structuur, verticale structuur en Voorwaarde = contact met 7110 of 7140_oli, % begroeid met opgaande vegetatie.
+  De waarde(n) voor de voorwaarde(n) contact met 7110 of 7140_oli, % begroeid met opgaande vegetatie grootste vegetatievlek in m², bedekking submerse vegetatie, bedekking overhangende bomen en struiken (VoorwaardeID 2139, 2, 2321, 1480, 1178) kunnen niet berekend worden voor opname(n) IV2021012910413902, IV2023011817014307, IV2023080114033170, IV2023083109223750, IV2024011616290864, IV2024011710122457, IV2024051512574509. Geef de waarde voor deze voorwaarde rechtstreeks in als input van de functie 'berekenLSVIBasis' via tabel 'Data_voorwaarden' (zie ?berekenLSVIbasis voor meer info). Vermeld hierbij Criterium = Structuur, Indicator = horizontale structuur, verticale structuur en Voorwaarde = contact met 7110 of 7140_oli, % begroeid met opgaande vegetatie.
   --> missing values; aan te vullen door Jo/Kevin (to do opvolgen; ook voor 2190)
 
 4: There were 12 warnings in `summarise()`.
@@ -257,7 +258,7 @@ ResKT <- ResDetail %>%
 ```{r}
 resultaat_tabel <- ResKT %>% 
   select(location, Habitattype, date, Versie, 
-         `% begroeid met opgaande vegetatie`:`kranswiervelden voor > = 50 % sleutelsoorten`) 
+         `% begroeid met opgaande vegetatie`:`scoresom niet-hydrofyten`) 
 resultaat_tabel %>% 
   kable() %>% 
   column_spec(5, background = ifelse(is.na(resultaat_tabel[5]), "white", 
@@ -284,6 +285,20 @@ resultaat_tabel %>%
                             ifelse(resultaat_tabel[15] == TRUE, "green", "red"))) %>% 
   column_spec(16, background = ifelse(is.na(resultaat_tabel[16]), "white", 
                             ifelse(resultaat_tabel[16] == TRUE, "green", "red"))) %>%
+  column_spec(17, background = ifelse(is.na(resultaat_tabel[16]), "white", 
+                            ifelse(resultaat_tabel[16] == TRUE, "green", "red"))) %>%
+  column_spec(18, background = ifelse(is.na(resultaat_tabel[16]), "white", 
+                            ifelse(resultaat_tabel[16] == TRUE, "green", "red"))) %>%
+  column_spec(19, background = ifelse(is.na(resultaat_tabel[16]), "white", 
+                            ifelse(resultaat_tabel[16] == TRUE, "green", "red"))) %>%  
+  column_spec(20, background = ifelse(is.na(resultaat_tabel[16]), "white", 
+                            ifelse(resultaat_tabel[16] == TRUE, "green", "red"))) %>%
+  column_spec(21, background = ifelse(is.na(resultaat_tabel[16]), "white", 
+                            ifelse(resultaat_tabel[16] == TRUE, "green", "red"))) %>%
+  column_spec(22, background = ifelse(is.na(resultaat_tabel[16]), "white", 
+                            ifelse(resultaat_tabel[16] == TRUE, "green", "red"))) %>%
+  column_spec(23, background = ifelse(is.na(resultaat_tabel[16]), "white", 
+                            ifelse(resultaat_tabel[16] == TRUE, "green", "red"))) %>%  
   kable_styling() %>% 
   scroll_box(height = "500px")
 # to do (later): code opmaak inkorten
@@ -293,14 +308,21 @@ figuur eindoordeel per locatie
 ```{r}
 ResGlob %>% 
   mutate(Habitattype = as.factor(Habitattype), 
-         Status2 = ifelse(Status == T, "gunstig", "ongunstig")) %>% 
-  ggplot(aes(x = Habitattype, fill = Status2)) +
+         status = ifelse(Status == T, "gunstig", "ongunstig")) %>% 
+  ggplot(aes(x = Habitattype, fill = status)) +
+  scale_fill_manual(values = c("gunstig" = "green",
+                               "ongunstig" = "red")) +
   geom_bar()
 ```
 
+# export brondata
+```{r}
+write.csv2(data_habitat, paste0(path, "/HT31xx_data_habitat.csv"))
+write.csv2(data_voorwaarden, paste0(path, "/HT31xx_data_voorwaarden.csv"))
+write.csv2(data_soortenkenmerken, paste0(path, "/HT31xx_data_soortenkenmerken.csv"))
+```
 
 # export resultaten 
-
 ```{r}
 write.csv2(ResDetail, paste0(path, "/HT31xx_ResultaatLSVI_detail.csv"))
 write.csv2(ResCrit, paste0(path, "/HT31xx_ResultaatLSVI_criteria.csv"))

--- a/src/export_from_inboveg/HT31xx_data_exploration.Rmd
+++ b/src/export_from_inboveg/HT31xx_data_exploration.Rmd
@@ -79,7 +79,7 @@ site_characteristics %>%
     TRUE ~ value_numeric)) %>% 
   ggplot(aes(x = value_calc)) + 
   geom_histogram() +
-  facet_wrap(~Voorwaarde, scales = "free")
+  facet_wrap(~var, scales = "free")
 ```
 
 ### class variables
@@ -88,7 +88,7 @@ site_characteristics %>%
   filter(is_numeric == FALSE) %>% 
   ggplot(aes(x = value_description)) + 
   geom_bar() +
-  facet_grid(Voorwaarde~., scales = "free") +
+  facet_grid(var~., scales = "free") +
   coord_flip()
 ```
 
@@ -124,8 +124,8 @@ site_characteristics %>%
     is_below_LOQ == TRUE ~ value_numeric/2, # halvering voor waarden < x 
     is_above_LOQ == TRUE ~ value_numeric, # waarde overnemen voor > x
     TRUE ~ value_numeric)) %>%
-  select(user_reference, Voorwaarde, value_calc) %>% 
-  spread(Voorwaarde, value_calc) %>% 
+  select(user_reference, var, value_calc) %>% 
+  spread(var, value_calc) %>% 
   ggplot(aes(x = `diepte van secchibepaling`, y = `secchi-diepte`)) + 
   geom_point() +
   geom_abline(slope = 1, color = "red", linetype = "dashed") 
@@ -156,17 +156,17 @@ data_breed <- header %>%
 
 N_dataset <- nrow(data_breed)
 summary_dataset <- data_breed %>% 
-  gather("Voorwaarde", "value", 
+  gather("var", "value", 
          -recording_givid, -survey, -user_reference, -location, -date, 
          -latitude, -longitude, -type_observed, reliability, -suitable_mhq, 
          -measured, 
          na.rm = TRUE) %>% 
-  group_by(Voorwaarde, type_observed) %>% 
+  group_by(var, type_observed) %>% 
   summarise(number = n(),  
             sd = sd(value),
             ratio_NA = 1- (number/N_dataset)) 
 
-ggplot(summary_dataset, aes(x = ratio_NA, y = Voorwaarde)) +
+ggplot(summary_dataset, aes(x = ratio_NA, y = var)) +
   geom_point() + 
   facet_wrap(~type_observed)
 ```

--- a/src/export_from_inboveg/HT31xx_data_exploration.Rmd
+++ b/src/export_from_inboveg/HT31xx_data_exploration.Rmd
@@ -79,7 +79,7 @@ site_characteristics %>%
     TRUE ~ value_numeric)) %>% 
   ggplot(aes(x = value_calc)) + 
   geom_histogram() +
-  facet_wrap(~var, scales = "free")
+  facet_wrap(~Voorwaarde, scales = "free")
 ```
 
 ### class variables
@@ -88,7 +88,7 @@ site_characteristics %>%
   filter(is_numeric == FALSE) %>% 
   ggplot(aes(x = value_description)) + 
   geom_bar() +
-  facet_grid(var~., scales = "free") +
+  facet_grid(Voorwaarde~., scales = "free") +
   coord_flip()
 ```
 
@@ -124,8 +124,8 @@ site_characteristics %>%
     is_below_LOQ == TRUE ~ value_numeric/2, # halvering voor waarden < x 
     is_above_LOQ == TRUE ~ value_numeric, # waarde overnemen voor > x
     TRUE ~ value_numeric)) %>%
-  select(user_reference, var, value_calc) %>% 
-  spread(var, value_calc) %>% 
+  select(user_reference, Voorwaarde, value_calc) %>% 
+  spread(Voorwaarde, value_calc) %>% 
   ggplot(aes(x = `diepte van secchibepaling`, y = `secchi-diepte`)) + 
   geom_point() +
   geom_abline(slope = 1, color = "red", linetype = "dashed") 
@@ -156,17 +156,17 @@ data_breed <- header %>%
 
 N_dataset <- nrow(data_breed)
 summary_dataset <- data_breed %>% 
-  gather("var", "value", 
+  gather("Voorwaarde", "value", 
          -recording_givid, -survey, -user_reference, -location, -date, 
          -latitude, -longitude, -type_observed, reliability, -suitable_mhq, 
          -measured, 
          na.rm = TRUE) %>% 
-  group_by(var, type_observed) %>% 
+  group_by(Voorwaarde, type_observed) %>% 
   summarise(number = n(),  
             sd = sd(value),
             ratio_NA = 1- (number/N_dataset)) 
 
-ggplot(summary_dataset, aes(x = ratio_NA, y = var)) +
+ggplot(summary_dataset, aes(x = ratio_NA, y = Voorwaarde)) +
   geom_point() + 
   facet_wrap(~type_observed)
 ```

--- a/src/export_from_inboveg/HT31xx_data_exploration.Rmd
+++ b/src/export_from_inboveg/HT31xx_data_exploration.Rmd
@@ -114,7 +114,6 @@ site_characteristics %>%
 ```
 
 te checken (to do: opvolgen):   
-- check max diepte van 75m in lage diepteklasse  
 - in klasse 2-4m één met kleinere maximale diepte (AN_DVH_007_3130n_17)  
 
 ### Secchi-diepte versus diepte Secchibepaling
@@ -174,7 +173,7 @@ ggplot(summary_dataset, aes(x = ratio_NA, y = var)) +
 
 conclusie:  
 - % sleutelsoorten niet altijd ingevuld (maar niet nodig voor LSVI-berekening)  
-- maximale diepte niet overal genoteerd (nodig voor LSVI-berekening?)  
+- maximale diepte niet overal genoteerd (maar is niet nodig voor LSVI-berekening)  
 - ter info: verticale structuur zit bij 3130 na niet bij 'verst' --> zit bij HabVl!  
 
 
@@ -237,6 +236,6 @@ verstoring_3160 %>%
   scroll_box(height = "800px")
 ```
 
---> NA bij AN_SNE_001_3160_15, LI_HEU_001_3160_15, LI_TEU_002_3160_14, LI_ZPB_001_2020 (to do: opvolgen)  
+--> NA bij LIMHHE0002_3160_2023, LI_HEU_001_3160_15, LI_TEU_002_3160_14, LI_ZPB_001_3160_20 (to do: opvolgen)  
 --> check: EutrSS < Eutro --> is ok   
 --> check: VZuSS < Vzuur --> is ok  

--- a/src/export_from_inboveg/HT31xx_data_exploration.Rmd
+++ b/src/export_from_inboveg/HT31xx_data_exploration.Rmd
@@ -114,7 +114,7 @@ site_characteristics %>%
 ```
 
 te checken (to do: opvolgen):   
-- in klasse 2-4m één met kleinere maximale diepte (AN_DVH_007_3130n_17)  
+- in klasse 2-4m één met kleinere maximale diepte (AN_DVH_001_3130n_18)  
 
 ### Secchi-diepte versus diepte Secchibepaling
 ```{r}
@@ -168,7 +168,7 @@ summary_dataset <- data_breed %>%
 
 ggplot(summary_dataset, aes(x = ratio_NA, y = var)) +
   geom_point() + 
-  facet_wrap(~type_observed)
+  facet_grid(~type_observed)
 ```
 
 conclusie:  

--- a/src/export_from_inboveg/HT31xx_data_preparation.Rmd
+++ b/src/export_from_inboveg/HT31xx_data_preparation.Rmd
@@ -73,18 +73,20 @@ sitequal <- sitequal_31xx %>%
 identify recording_givid with no or partial measurements
 ```{r}
 no_classification <- anti_join(header_31xx, classif_31xx, by = "recording_givid") 
-      # to do: 4 opnames: op te volgen
+      # to do: 1 opnames: op te volgen
 no_structure <- anti_join(header_31xx, structure_31xx, by = "recording_givid") 
       # to do: 1 lege opname; op te volgen
 no_layers <- anti_join(header_31xx, layerqual_31xx, by = "recording_givid") 
       # to do: 2 lege opnames; op te volgen
 no_vegetation <- anti_join(header_31xx, vegetation_31xx, by = "recording_givid") 
-      # to do: 3 opnames 31xx & 8 opnames 2190a: op te volgen
-no_survey <- bind_rows(no_classification, no_structure, no_layers, no_vegetation) %>% 
+      # to do: 2 opnames 31xx & 8 opnames 2190a: op te volgen
+      # een aantal opnames hebben effectief geen soorten in de opname; andere zijn invoerfouten
+      # voorlopig in analyse laten (owv effectieve opnames zonder soorten; zie 2190a)
+no_survey <- bind_rows(no_classification, no_structure, no_layers) %>% 
   distinct()
-
-# to do: toevoeging drooggevallen --> suitable_mhq = FALSE
-
+dry <- structure_31xx %>% 
+  filter(var_code == "peil", var_value_code == "Droog")
+      # bij droogval: opname is ongeschikt voor LSVI-bepaling
 ```
 
 ```{r}
@@ -98,7 +100,9 @@ header <- header_31xx %>%
                                   labels = c("gh", stilstaande_typen))) %>% 
   left_join(sitequal, by = c("survey", "recording_givid", "user_reference")) %>% 
   mutate(suitable_mhq = ifelse(test = (type_observed %in% stilstaande_typen), 
-                          yes = TRUE,
+                          yes = ifelse(test = (recording_givid %in% dry$recording_givid),
+                                       yes = FALSE,
+                                       no = TRUE),
                           no = FALSE),
          measured = ifelse(test = recording_givid %in% no_survey$recording_givid,
                          yes = FALSE,
@@ -233,7 +237,6 @@ structure_num_2 <- structure_31xx %>%
          value_numeric = as.numeric(str_replace(value_numeric, ",", "\\."))) %>% 
   select(survey, recording_givid, user_reference, var_code = var_value_code, 
          var = var_description_or_value, value, value_description, value_numeric)  
-
 ```
 
 mogelijke probleemgevallen
@@ -374,6 +377,7 @@ vegetation <- vegetation_31xx %>%
   mutate(name = ifelse(is.na(name_scientific), name_original, name_scientific),
          name = case_when(
            name_original %in% c("draadwier", "Draadwier spec.") ~ "Draadwier",
+           name_original %in% c("Chara hispida L.", "Chara hispida") ~ "Chara hispida",
            name_original %in% 
              c("Hydrodictyon reticulatum (Linnaeus) Bory", 
                "Hydrodictyon reticulatum Lagerh.") ~ "Hydrodictyon reticulatum",

--- a/src/export_from_inboveg/HT31xx_data_preparation.Rmd
+++ b/src/export_from_inboveg/HT31xx_data_preparation.Rmd
@@ -309,11 +309,11 @@ voor 3160 verschil tussen LSVI versie 2 en versie 3 door verschillende soortenli
 
 ```{r}
 site_characteristics <- bind_rows(structure, layerqual) %>%
-    mutate(Voorwaarde = str_to_lower(var),
-           Voorwaarde = str_remove(Voorwaarde, 
+    mutate(var = str_to_lower(var),
+           var = str_remove(var, 
                              paste(c(" \\(\\%\\)", " in meter", " in m"), 
                                    collapse = "|")),
-           Voorwaarde = str_remove(var, "31xx_lsvi_|31xx_"),
+           var = str_remove(var, "31xx_lsvi_|31xx_"),
            value = str_to_lower(value)) %>% 
   select(-var)
 ```
@@ -322,7 +322,7 @@ replace NA in var en value_description
 ```{r}
 # to do: moet eigenlijk opgelost worden in INBOVEG (opvolgen)
 tbl_var <- site_characteristics %>% 
-  select(survey, var_code, var2 = Voorwaarde) %>% 
+  select(survey, var_code, var2 = var) %>% 
   filter(!is.na(var2)) %>% 
   distinct()
 
@@ -333,7 +333,7 @@ tbl_value_description <- site_characteristics %>%
 
 site_characteristics <- site_characteristics %>%  
   left_join(tbl_var, by = c("survey", "var_code")) %>% 
-  mutate(Voorwaarde = var2) %>% 
+  mutate(var = var2) %>% 
   select(-var2) %>% 
   left_join(tbl_value_description, by = c("survey", "value")) %>% 
   mutate(value_description = vd2) %>% 
@@ -420,7 +420,7 @@ write.csv2(vegetation, paste0(path, "/HT31xx_vegetation.csv"))
 write_vc(header, "HT31xx_header", root = path, 
          sorting = c("recording_givid"), strict = FALSE)
 write_vc(site_characteristics, "HT31xx_site_characteristics", root = path, 
-         sorting = c("recording_givid", "Voorwaarde", "value"), strict = FALSE)
+         sorting = c("recording_givid", "var", "value"), strict = FALSE)
 write_vc(vegetation, "HT31xx_vegetation", root = path, 
          sorting = c("recording_givid", "name", "phenology_code"))
 ```

--- a/src/export_from_inboveg/HT31xx_data_preparation.Rmd
+++ b/src/export_from_inboveg/HT31xx_data_preparation.Rmd
@@ -115,7 +115,7 @@ beschrijving van enkele kolommen:
 
 * type_observed: gh (-9, geen habitat); `r stilstaande_typen`  
 * reliability: betrouwbaarheid vegetatieopname: hoog (misschien soorten over het hoofd gezien); matig (waarschijnlijk soorten over het hoofd gezien); laag (zeker soorten over het hoofd gezien)  
-* suitable_mhq (TRUE/FALSE): geschiktheid voor opname in het habitatkwaliteitsmeetnet: TRUE indien type_observed een type bevat van de lijst van stilstaande wateren 
+* suitable_mhq (TRUE/FALSE): geschiktheid voor opname in het habitatkwaliteitsmeetnet: TRUE indien type_observed een type bevat van de lijst van stilstaande wateren; FALSE: indien geen type van van de lijst of indien drooggevallen 
 * measured (TRUE/FALSE): geeft aan of er al dan niet een vegetatieopname is uitgevoerd (TRUE); een onvolledige opname (geen structuur- layer- of vegetatieknemerken genoteerd) wordt als FALSE beschouwd  
 
 ```{r}

--- a/src/export_from_inboveg/HT31xx_data_preparation.Rmd
+++ b/src/export_from_inboveg/HT31xx_data_preparation.Rmd
@@ -384,13 +384,15 @@ vegetation <- vegetation_31xx %>%
            name_original %in% 
              c("kroossoorten", 
                "kroossoorten (= Lemna sp., Spirodela polyrhiza, Wolffia arrhiza Uitz. Lemna trisulca)",
-               "Kroossoorten (= Lemna sp., Spirodela polyrhiza, Wolffia arrhiza Uitz. Lemna trisulca)") ~ "Lemna",
+               "Kroossoorten (= Lemna sp., Spirodela polyrhiza, Wolffia arrhiza Uitz. Lemna trisulca)") 
+           ~ "Lemna",
+           name_original == "Carex viridula s.l." ~ "Carex viridula Michaux",
             TRUE ~ name_original)) %>% 
-  # synoniemen van my taxa oplossen & deze veranderen zodat deze leesbaar zijn door LSVI-rekenmodule 
+        # synoniemen van my taxa en Carex viridula s.l. oplossen & deze veranderen 
+        # zodat deze leesbaar zijn voor de LSVI-rekenmodule 
   select(survey, recording_givid, name, phenology_code, species_cover_code, 
          species_cover, scale) %>% 
   distinct()  # sommige soorten staan er anders dubbel in omdat ze aan verschillende verstoringslagen zijn gekoppeld: Agrostis canina, ...
-
 ```
 
 Sommige taxa zijn een groepering van soorten en hebben geen wetenschappelijke naam in INBOVEG. Voor de ontbrekende namen bij name_scientific, wordt de name_original overgenomen in de 'name'.

--- a/src/export_from_inboveg/HT31xx_data_preparation.Rmd
+++ b/src/export_from_inboveg/HT31xx_data_preparation.Rmd
@@ -309,21 +309,20 @@ voor 3160 verschil tussen LSVI versie 2 en versie 3 door verschillende soortenli
 
 ```{r}
 site_characteristics <- bind_rows(structure, layerqual) %>%
-    mutate(var = str_to_lower(var),
-           var = str_remove(var, 
+    mutate(Voorwaarde = str_to_lower(var),
+           Voorwaarde = str_remove(Voorwaarde, 
                              paste(c(" \\(\\%\\)", " in meter", " in m"), 
                                    collapse = "|")),
-           var = str_remove(var, "31xx_lsvi_|31xx_"),
-           value = str_to_lower(value)) 
-# to do (later): if you use de 'Voorwaarde'-name in the LSVI-database for 'var' you do 
-# not have to change it afterwards when calculating LSVI. 
+           Voorwaarde = str_remove(var, "31xx_lsvi_|31xx_"),
+           value = str_to_lower(value)) %>% 
+  select(-var)
 ```
 
 replace NA in var en value_description 
 ```{r}
 # to do: moet eigenlijk opgelost worden in INBOVEG (opvolgen)
 tbl_var <- site_characteristics %>% 
-  select(survey, var_code, var2 = var) %>% 
+  select(survey, var_code, var2 = Voorwaarde) %>% 
   filter(!is.na(var2)) %>% 
   distinct()
 
@@ -334,7 +333,7 @@ tbl_value_description <- site_characteristics %>%
 
 site_characteristics <- site_characteristics %>%  
   left_join(tbl_var, by = c("survey", "var_code")) %>% 
-  mutate(var = var2) %>% 
+  mutate(Voorwaarde = var2) %>% 
   select(-var2) %>% 
   left_join(tbl_value_description, by = c("survey", "value")) %>% 
   mutate(value_description = vd2) %>% 
@@ -421,7 +420,7 @@ write.csv2(vegetation, paste0(path, "/HT31xx_vegetation.csv"))
 write_vc(header, "HT31xx_header", root = path, 
          sorting = c("recording_givid"), strict = FALSE)
 write_vc(site_characteristics, "HT31xx_site_characteristics", root = path, 
-         sorting = c("recording_givid", "var", "value"), strict = FALSE)
+         sorting = c("recording_givid", "Voorwaarde", "value"), strict = FALSE)
 write_vc(vegetation, "HT31xx_vegetation", root = path, 
          sorting = c("recording_givid", "name", "phenology_code"))
 ```

--- a/src/export_from_inboveg/HT31xx_data_preparation.Rmd
+++ b/src/export_from_inboveg/HT31xx_data_preparation.Rmd
@@ -73,18 +73,18 @@ sitequal <- sitequal_31xx %>%
 identify recording_givid with no or partial measurements
 ```{r}
 no_classification <- anti_join(header_31xx, classif_31xx, by = "recording_givid") 
-      # to do: 3 opnames: op te volgen
+      # to do: 4 opnames: op te volgen
 no_structure <- anti_join(header_31xx, structure_31xx, by = "recording_givid") 
-      # to do: 2 lege opnames; op te volgen
-no_layers <- anti_join(header_31xx, layerqual_31xx, by = "recording_givid") 
       # to do: 1 lege opname; op te volgen
+no_layers <- anti_join(header_31xx, layerqual_31xx, by = "recording_givid") 
+      # to do: 2 lege opnames; op te volgen
 no_vegetation <- anti_join(header_31xx, vegetation_31xx, by = "recording_givid") 
-      # to do: 3 opnames 31xx & 25 opnames 2190a: op te volgen
+      # to do: 3 opnames 31xx & 8 opnames 2190a: op te volgen
 no_survey <- bind_rows(no_classification, no_structure, no_layers, no_vegetation) %>% 
   distinct()
 
-# to do: als 2190a-opnames volledig zijn ingevoerd; volledig controleren 
-# (vnl info over layers ontbreekt nog)
+# to do: toevoeging drooggevallen --> suitable_mhq = FALSE
+
 ```
 
 ```{r}
@@ -134,6 +134,7 @@ var_class <- c("boom", "chara", "diept", "horst", "peil", "verst", "permw")
   # klassevariabelen 
 var_multiple <- c("helde", "subst") 
   # klassevariabelen, met meerdere keuzemogelijkheden per bezoek
+  # substraat is bij 2190 zowel zonder als met % opgegeven --> dus bij multiple houden
 var_num_1 <- c("diept") 
   # numerieke variabelen, afgeleid van var_code (= info voor maximale diepte)
 var_num_2 <- c("Seccd", "Secch", "Schom", "HabVl", "Helo") 
@@ -172,7 +173,6 @@ structure_class <- structure_31xx %>%
          value = val2, value_description = var_description_or_value) %>% 
   mutate(value_numeric = NA, is_below_LOQ = FALSE, is_above_LOQ = FALSE, 
          is_numeric = FALSE, unit = "class")
-# to do: opvolgen of substraat bij 2190 als % is opgegeven (dus numeriek) of niet (klasse)
 ```
 
 #### structure - numeriek (in var_code)
@@ -241,8 +241,6 @@ mogelijke probleemgevallen
 structure_num_2 %>% 
   filter(is.na(value_numeric)) %>% 
   select(user_reference, var_code, var, value) 
-# to do: opvolgen of 'zie afgedrukt veldformulier' verwijderd is (1 case; heuvelsven)
-# LI_HEU_001_3130a_22
 ```
 
 indien er probleemgevallen zijn, worden deze voorlopig in de volgende stap gewist  

--- a/src/export_from_inboveg/HT31xx_data_preparation.Rmd
+++ b/src/export_from_inboveg/HT31xx_data_preparation.Rmd
@@ -314,8 +314,7 @@ site_characteristics <- bind_rows(structure, layerqual) %>%
                              paste(c(" \\(\\%\\)", " in meter", " in m"), 
                                    collapse = "|")),
            var = str_remove(var, "31xx_lsvi_|31xx_"),
-           value = str_to_lower(value)) %>% 
-  select(-var)
+           value = str_to_lower(value)) 
 ```
 
 replace NA in var en value_description 


### PR DESCRIPTION
De opnames van habitattype 2190a zijn ondertussen aangevuld in de survey "HT2190_a_LSVI_StilstaandeWateren" van INBOVEG. De gewijzigde code voor de LSVI-berekeningen van de aquatische habitattypen omvat:  
- checks voor deze nieuwe opnames; 
- opsomming van nieuwe waarschuwingen van de nieuwe data bij de berekening door de LSVI-rekenmodule, die opgevolgd moeten worden; 
- optimalisaties en controles om de LSVI voor habitattype 2190a te kunnen bepalen;
- toevoeging dat een opname ongeschikt is bij droogval;
- omzeiling van een taxon-probleem waarbij s.l.-taxa fout worden doorgerekend in de LSVI-rekenmodule.