### PR TITLE
oplossing error git2rdata bij berekenLSVIbasis()

### DIFF
--- a/src/export_from_inboveg/HT31xx_LSVI.Rmd
+++ b/src/export_from_inboveg/HT31xx_LSVI.Rmd
@@ -32,9 +32,12 @@ maakConnectiePool()
 ```{r}
 path <- str_c(fileman_up("n2khab-mhq-data"), "/processed/inboveg_mhq_aq")
 
-header <- read_vc("HT31xx_header", root = path)
-site_characteristics <- read_vc("HT31xx_site_characteristics", root = path)
-vegetation <- read_vc("HT31xx_vegetation", root = path)
+header <- read_vc("HT31xx_header", root = path) %>% 
+  as.data.frame()
+site_characteristics <- read_vc("HT31xx_site_characteristics", root = path) %>% 
+  as.data.frame()
+vegetation <- read_vc("HT31xx_vegetation", root = path) %>% 
+  as.data.frame()
 ```
 to do (later): link maken met xls met svz van monitoring
 


### PR DESCRIPTION
Door de installatie van een nieuwe versie van R werkte de functie berekendLSVIbasis() niet meer. Door het data type te wijzigen naar een data.frame is dit probleem voorlopig verholpen. 